### PR TITLE
Update validate to commit a terraform fmt

### DIFF
--- a/.github/workflows/tf-validate-shared.yml
+++ b/.github/workflows/tf-validate-shared.yml
@@ -18,10 +18,14 @@ jobs:
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v2
       
-      - name: Check format and validate
+      - name: Do format
         run:
-          terraform fmt -check -recursive; terraform init -backend=false; terraform validate
-      - uses: EndBug/add-and-commit@v9
+          terraform fmt -recursive
+      - name: Check validate
+        run:
+          terraform init -backend=false; terraform validate
+      - name: Commit terraform fmt
+        uses: EndBug/add-and-commit@v9
         with:
           message: 'Terraform fmt completed'
           add: '*.tf'

--- a/.github/workflows/tf-validate-shared.yml
+++ b/.github/workflows/tf-validate-shared.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Commit terraform fmt
         uses: EndBug/add-and-commit@v9
         with:
-          message: 'Terraform fmt completed'
+          message: 'AUTOMATED ACTION: Terraform fmt completed'
           add: '*.tf'

--- a/.github/workflows/tf-validate-shared.yml
+++ b/.github/workflows/tf-validate-shared.yml
@@ -21,3 +21,7 @@ jobs:
       - name: Check format and validate
         run:
           terraform fmt -check -recursive; terraform init -backend=false; terraform validate
+      - uses: EndBug/add-and-commit@v9
+        with:
+          message: 'Terraform fmt completed'
+          add: '*.tf'


### PR DESCRIPTION
## Purpose:
This update changes our validate step to automatically commit a terraform fmt to the repo in the branch you're working in.  This is helpful for users that are using the github editor, which lacks the terraform binary.  

To do this, i separated the validate and format steps, so we have a clearer understanding of what went wrong if there's a failure.  
I added a step which creates a commit with the update if there is one to create, in theory, this is just if there's a fmt that has changed files.  

To test this, I created a private repo and updated my action to use 
```
jobs:
  validate:
    name: Validate Terraform
    uses: stigian/.github/.github/workflows/tf-validate-shared.yml@autofmt
```

The results were that I can see when i update a file with some terraform that is not formatted:
![image](https://github.com/stigian/.github/assets/7454082/6614155a-c50d-49b7-84ea-7f9ed5cd2ab4)

A commit follows with a terraform fmt completed. 